### PR TITLE
Adding a custom field which will host a mark for all runs created at …

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@
 ### <del>Upload failed scenarios at the last create-run requests in order to set the instance failed</del>
 ### <del>Download instances following pagination info</del>
 ### <del>Split create-run requests every 20 scenarios</del>
+### <del>Create a parameter in order to mark runs belonging to the same scenario outline execution for PractiTest reports</del>
 ### Any screenshot at any page, not only standard screenshot-at-failed-page-for-failed-step
 
 ## Pre-requisites

--- a/practiTestUploadRun.py
+++ b/practiTestUploadRun.py
@@ -8,6 +8,7 @@ import requests
 from jsonpath_ng.ext import parse
 from practitest_urls import *
 from screenshotFileName import get_screenshot_file_name
+from datetime import datetime
 
 status_mapping = {'passed': 'PASSED', 'failed': 'FAILED', 'skipped': 'NO RUN'}
 
@@ -58,6 +59,10 @@ def create_practiTest_run(custom_fields, reportDict):
     practitest_run = {
         "data": []
     }
+
+    run_number = datetime.strftime(datetime.today(), '%Y%m%d%H%M%S')
+    run_number_custom_field = '---f-' + str([match.value for match in parse("$.data[?(@.attributes.name=='Run Number')].id")
+        .find(custom_fields)][0])
 
     # for each feature
     for feature in reportDict:
@@ -290,9 +295,9 @@ def main():
     custom_fields = get_custom_fields(args.project_id)
 
     # load json report as python dict
-    reportDict = json.load(args.report)
+    report_dict = json.load(args.report)
 
-    practitest_run = create_practiTest_run(custom_fields, reportDict)
+    practitest_run = create_practiTest_run(custom_fields, report_dict)
 
     # Since API does nota allow the same instance twice in the body, even if they have different custom field value
     # ... this method is not valid


### PR DESCRIPTION
…this execution, this way Practi Test reports will be able to links runs belonging to same scenario outline